### PR TITLE
Do not store socket_addr and slave_id in Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ repository = "https://github.com/lukaskirner/tokio-sunspec"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.21.2", features = ["full"] }
-tokio-modbus = { version = "0.6", default-features = false, features = ["tcp", "server", "tcp-server-unstable"] }
-thiserror = "1.0.38"
+tokio = { version = "1.26.0", features = ["full"] }
+tokio-modbus = { version = "0.7", default-features = false, features = ["tcp", "server", "tcp-server-unstable"] }
+thiserror = "1.0.39"


### PR DESCRIPTION
Only connect_tcp uses these variables. After connecting all that's needed for communication with the inverter is the Context.

By not storing the socket_addr and slave_id, the Client struct is also usable for Modbus-RTU connections (even though there is no helper to set up the context -- the caller can do this on their own).