### PR TITLE
Add the ability to query multiple devices using the same Client

### DIFF
--- a/tests/read_string.rs
+++ b/tests/read_string.rs
@@ -23,7 +23,10 @@ async fn client_context(socket_addr: SocketAddr, s_id: u8, start_addr: u16) -> R
     // Connect client
     let mut client = tokio_sunspec::connect_tcp(socket_addr, s_id, start_addr).await?;
 
-    let mut model_ids = Vec::from_iter(client.models.keys().cloned());
+    let slave_ids = Vec::from_iter(client.models.keys().cloned());
+    assert_eq!(slave_ids, vec![s_id]);
+
+    let mut model_ids = Vec::from_iter(client.models.get(&s_id).unwrap().keys().cloned());
     model_ids.sort();
     assert_eq!(model_ids, vec![1]);
 

--- a/tests/write_string.rs
+++ b/tests/write_string.rs
@@ -24,7 +24,10 @@ async fn client_context(socket_addr: SocketAddr, s_id: u8, start_addr: u16) -> R
     // Connect client
     let mut client = tokio_sunspec::connect_tcp(socket_addr, s_id, start_addr).await?;
 
-    let mut model_ids = Vec::from_iter(client.models.keys().cloned());
+    let slave_ids = Vec::from_iter(client.models.keys().cloned());
+    assert_eq!(slave_ids, vec![s_id]);
+
+    let mut model_ids = Vec::from_iter(client.models.get(&s_id).unwrap().keys().cloned());
     model_ids.sort();
     assert_eq!(model_ids, vec![1]);
 


### PR DESCRIPTION
This change makes it so you can query multiple SunSpec devices on a single connection, removing the overhead of reconnecting (and re-scanning for available models) and/or keeping multiple connections active at the same time.

Multiple inverters can be connected together using RS-485, or on the same TCP connection. For instance, APSystems micro-inverters each show up on separate addresses on the same Modbus instance on the ECU box.